### PR TITLE
Add unit declarator to module and role declarations

### DIFF
--- a/lib/Method/Modifiers.pm6
+++ b/lib/Method/Modifiers.pm6
@@ -1,4 +1,4 @@
-module Method::Modifiers;
+unit module Method::Modifiers;
 
 sub around ($class, $method-name, &closure) is export
 {

--- a/lib/Method/Modifiers/Role.pm6
+++ b/lib/Method/Modifiers/Role.pm6
@@ -1,6 +1,6 @@
 use Method::Modifiers;
 
-role Method::Modifiers::Role;
+unit role Method::Modifiers::Role;
 
 method before ($method-name, &closure)
 {


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class`, `role` or `grammar` declarations (unless it uses a
block).  Code still using the old blockless semicolon form will throw a
warning. This commit stops the warning from appearing in the new Rakudo.
