### PR TITLE
Fix removed @*INC

### DIFF
--- a/t/01-functions.t
+++ b/t/01-functions.t
@@ -2,7 +2,7 @@
 
 use v6;
 
-BEGIN @*INC.push: './lib';
+use lib 'lib';
 
 use Test;
 use Method::Modifiers;

--- a/t/02-augment.t
+++ b/t/02-augment.t
@@ -2,7 +2,7 @@
 
 use v6;
 
-BEGIN @*INC.push: './lib';
+use lib 'lib';
 
 use Test;
 use Method::Modifiers::Augment;


### PR DESCRIPTION
@*INC is no longer available. `use lib` is the new way.
