### PR TITLE
Specify a non-asterisk version in META

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
   "perl"        : "6.*",
   "name"        : "Method::Modifiers",
-  "version"     : "*",
+  "version"     : "0.1.0",
   "description" : "Adds before, after and around functions to make wrapping method calls easier.",
   "provides"    : {
     "Method::Modifiers"          : "lib/Method/Modifiers.pm6",


### PR DESCRIPTION
Having an version with an asterisk fails the ecosystem tests.

See one such failure in https://travis-ci.com/github/Raku/ecosystem/builds/204007135 and Raku/ecosystem#567 for some added context